### PR TITLE
Adjustment to work with most recent prometheus-cpp and bazel releases

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ cc_binary(
     name = "conntrack_exporter",
     srcs = glob(["src/*.cc", "src/*h"]),
     deps = [
-        "@prometheus_cpp//:prometheus_cpp",
+        "@com_github_jupp0r_prometheus_cpp//pull",
         "@libnetfilter_conntrack//:libnetfilter_conntrack",
         "@argagg//:argagg",
     ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,12 @@
-git_repository(
-    name = "prometheus_cpp",
-    remote = "https://github.com/jupp0r/prometheus-cpp.git",
-    commit = "871a7673772b266135cc8422490578da1cf63004",
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+http_archive(
+    name = "com_github_jupp0r_prometheus_cpp",
+    strip_prefix = "prometheus-cpp-master",
+    urls = ["https://github.com/jupp0r/prometheus-cpp/archive/master.zip"],
 )
 
-load("@prometheus_cpp//:repositories.bzl", "prometheus_cpp_repositories")
+load("@com_github_jupp0r_prometheus_cpp//bazel:repositories.bzl", "prometheus_cpp_repositories")
+
 prometheus_cpp_repositories()
 
 load("//:repositories.bzl", "conntrack_exporter_dependencies")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
 def libnetfilter_conntrack_repositories():
 
     BUILD = """
@@ -27,7 +29,7 @@ cc_library(
 )
 """
 
-    native.new_git_repository(
+    new_git_repository(
         name = "argagg",
         remote = "https://github.com/vietjtnguyen/argagg.git",
         commit = "4c8c86180cfafb1448f583ed0973da8c2f559dd6",


### PR DESCRIPTION
Hi, here's all I had to adjust to build the conntrack_exporter with the most recent prometheus-cpp and bazel releases.

Hope this helps somebody.